### PR TITLE
feat: add minio config to service account config

### DIFF
--- a/sdk/service_account.go
+++ b/sdk/service_account.go
@@ -195,6 +195,18 @@ type ServiceAccountOptions struct {
 	// MaxRetries specifies the maximum number of retry attempts for failed requests (optional).
 	// Defaults to 3 if not specified.
 	MaxRetries int
+
+	// MinIOEndpoint is the MinIO endpoint for S3 operations (required).
+	MinIOEndpoint string
+
+	// MinIOAccessKey is the MinIO access key for S3 operations (required).
+	MinIOAccessKey string
+
+	// MinIOSecretKey is the MinIO secret key for S3 operations (required).
+	MinIOSecretKey string
+
+	// MinIORegion is the MinIO region for S3 operations (required).
+	MinIORegion string
 }
 
 // ToConfiguration converts the ServiceAccount to a utils.Configuration.
@@ -214,6 +226,10 @@ func (sa *ServiceAccount) ToConfiguration(opts ServiceAccountOptions) (utils.Con
 		KeycloakRealm:        realm,
 		KeycloakClientID:     sa.ClientID,
 		KeycloakClientSecret: sa.ClientSecret,
+		MinIOEndpoint:        opts.MinIOEndpoint,
+		MinIOAccessKey:       opts.MinIOAccessKey,
+		MinIOSecretKey:       opts.MinIOSecretKey,
+		MinIORegion:          opts.MinIORegion,
 	}
 
 	// Apply defaults for optional fields


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces MinIO configuration to enable S3 operations via service account–based clients.
> 
> - Adds `MinIOEndpoint`, `MinIOAccessKey`, `MinIOSecretKey`, `MinIORegion` to `ServiceAccountOptions`
> - Passes these fields through in `ToConfiguration` to `utils.Configuration`
> - Request timeout and retry defaults remain unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97f1fdf95b80598e5332a7a2caf454572188e7d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->